### PR TITLE
feat: add certified classics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .ds_store
 .env
 build/
+*.log

--- a/backend/src/middleware/logger.ts
+++ b/backend/src/middleware/logger.ts
@@ -1,6 +1,10 @@
 import morgan from 'morgan';
 import fs from 'fs';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const accessLogStream = fs.createWriteStream(
   path.join(__dirname, 'backend.log'),

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,13 +9,17 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-router": "^7.13.0",
+        "react-router-dom": "^7.13.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
+        "@types/react-router": "^5.1.20",
+        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^5.1.1",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -1376,6 +1380,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1411,6 +1422,29 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1909,6 +1943,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2808,6 +2855,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2875,6 +2960,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,8 +18,6 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
-        "@types/react-router": "^5.1.20",
-        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^5.1.1",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -1380,13 +1378,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/history": {
-      "version": "4.7.11",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
-      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1422,29 +1413,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-router": {
-      "version": "5.1.20",
-      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
-      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
-      }
-    },
-    "node_modules/@types/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,13 +11,17 @@
   },
   "dependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-router": "^7.13.0",
+    "react-router-dom": "^7.13.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
+    "@types/react-router": "^5.1.20",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,8 +20,6 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
-    "@types/react-router": "^5.1.20",
-    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,86 +1,16 @@
-import { useState, useEffect } from 'react'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './App.css'
+import Home from './modules/Home/index'
+import Classics from './modules/Classics'
 
 function App() {
-  const [foodName, setFoodName] = useState('')
-  const [responseData, setResponseData] = useState<any>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000'
-
-  const fetchFood = async (name: string) => {
-    if (name.length === 0) {
-      setResponseData(null)
-      setError(null)
-      return
-    }
-
-    setLoading(true)
-    setError(null)
-    setResponseData(null)
-
-    try {
-      const response = await fetch(`${backendUrl}/?food=${encodeURIComponent(name)}`)
-      if (!response.ok) {
-        throw new Error(`HTTP error! status: ${response.status}`)
-      }
-      const data = await response.json()
-      setResponseData(data)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'An error occurred')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      fetchFood(foodName)
-    }, 400)
-
-    return () => clearTimeout(timer)
-  }, [foodName])
-
   return (
-    <>
-      <h1>Unicafe foodfinder</h1>
-      <div className="input-container">
-        <input
-          type="text"
-          value={foodName}
-          onChange={(e) => setFoodName(e.target.value)}
-          placeholder="Enter food name"
-        />
-      </div>
-
-      {loading && <div style={{ marginTop: '20px' }}>Loading...</div>}
-
-      {error && <div style={{ color: 'red', marginTop: '20px' }}>Error: {error}</div>}
-
-      {responseData && (
-        <div>
-          <h2>Results:</h2>
-          <div>
-            {Object.entries(responseData).length === 0 && <p>No results found</p>}
-            {Object.entries(responseData).map(([restaurant, items]: [string, any]) => (
-              <div key={restaurant}>
-                <h3>{restaurant}</h3>
-                <div>
-                  {items.map((item: any[], index: number) => (
-                    <div key={index}>
-                      <div>- {item[0]}</div>
-                      <div>- {item[1]}</div>
-                      {item[2] && <>- Allergeenit: {item[2]}</>}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
-    </>
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/classics" element={<Classics />} />
+      </Routes>
+    </BrowserRouter>
   )
 }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -6,5 +6,5 @@ import App from './App.tsx'
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 )

--- a/frontend/src/modules/Classics/index.tsx
+++ b/frontend/src/modules/Classics/index.tsx
@@ -64,11 +64,15 @@ function Classics() {
       {certifiedClassics.map((food) => (
         <div key={food}>
           {availability[food]?.length !== 0 ? <h2>{food}</h2> : null}
-          {availability[food]?.map(({ restaurant, date }) => (
-            <li key={restaurant}>
-              {restaurant}: {date}
-            </li>
-          ))}
+          {availability[food]?.length ? (
+            <ul>
+              {availability[food].map(({ restaurant, date }) => (
+                <li key={restaurant}>
+                  {restaurant}: {date}
+                </li>
+              ))}
+            </ul>
+          ) : null}
         </div>
       ))}
     </>

--- a/frontend/src/modules/Classics/index.tsx
+++ b/frontend/src/modules/Classics/index.tsx
@@ -1,0 +1,78 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+const certifiedClassics = ['Kalapuikot', 'Meksikolainen uunimakkara', 'Rapeat kalapalat']
+
+type ClassicFoodAvailability = {
+  [food: string]: {
+    restaurant: string
+    date: string | null
+  }[]
+}
+
+type FoodItem = [string, string, string] // [date, matched_foodstring, allergens]
+
+type FoodResponse = {
+  [restaurantName: string]: Array<FoodItem>
+}
+
+function Classics() {
+  const navigate = useNavigate()
+  const [availability, setAvailability] = useState<ClassicFoodAvailability>({})
+
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000'
+
+  const fetchFood = async (name: string): Promise<FoodResponse | undefined> => {
+    try {
+      const response = await fetch(`${backendUrl}/?food=${encodeURIComponent(name)}`)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+      const data = await response.json()
+      return data
+    } catch (err) {
+      console.error('Error fetching food data:', err)
+    }
+  }
+
+  useEffect(() => {
+    const fetchAllFood = async () => {
+      for (const food of certifiedClassics) {
+        const data = await fetchFood(food)
+        if (data) {
+          setAvailability((prev) => ({
+            ...prev,
+            [food]: Object.entries(data).map(([restaurant, items]) => ({
+              restaurant,
+              date: items[0]?.[0] ?? null,
+            })),
+          }))
+        }
+      }
+    }
+    fetchAllFood()
+  }, [])
+
+  return (
+    <>
+      <header style={{ display: 'flex', gap: '10px', marginBottom: '20px' }}>
+        <button onClick={() => navigate('/')}>Home</button>
+        <button onClick={() => navigate('/classics')}>Classics</button>
+      </header>
+      <h1>Certified classics</h1>
+
+      {certifiedClassics.map((food) => (
+        <div key={food}>
+          {availability[food]?.length !== 0 ? <h2>{food}</h2> : null}
+          {availability[food]?.map(({ restaurant, date }) => (
+            <li key={restaurant}>
+              {restaurant}: {date}
+            </li>
+          ))}
+        </div>
+      ))}
+    </>
+  )
+}
+
+export default Classics

--- a/frontend/src/modules/Classics/index.tsx
+++ b/frontend/src/modules/Classics/index.tsx
@@ -66,7 +66,7 @@ function Classics() {
 
       {certifiedClassics.map((food) => (
         <div key={food}>
-          {availability[food]?.length > 0 ? <h2>{food}</h2> : null}
+          {availability[food]?.length ? <h2>{food}</h2> : null}
           {availability[food]?.length ? (
             <ul>
               {availability[food].map(({ restaurant, date }) => (

--- a/frontend/src/modules/Classics/index.tsx
+++ b/frontend/src/modules/Classics/index.tsx
@@ -37,18 +37,21 @@ function Classics() {
 
   useEffect(() => {
     const fetchAllFood = async () => {
-      for (const food of certifiedClassics) {
+      const promises = certifiedClassics.map(async (food) => {
         const data = await fetchFood(food)
+        return { food, data }
+      })
+      const results = await Promise.all(promises)
+      const newAvailability: ClassicFoodAvailability = {}
+      results.forEach(({ food, data }) => {
         if (data) {
-          setAvailability((prev) => ({
-            ...prev,
-            [food]: Object.entries(data).map(([restaurant, items]) => ({
-              restaurant,
-              date: items[0]?.[0] ?? null,
-            })),
+          newAvailability[food] = Object.entries(data).map(([restaurant, items]) => ({
+            restaurant,
+            date: items[0]?.[0] ?? null,
           }))
         }
-      }
+      })
+      setAvailability(newAvailability)
     }
     fetchAllFood()
   }, [])

--- a/frontend/src/modules/Classics/index.tsx
+++ b/frontend/src/modules/Classics/index.tsx
@@ -66,7 +66,7 @@ function Classics() {
 
       {certifiedClassics.map((food) => (
         <div key={food}>
-          {availability[food]?.length !== 0 ? <h2>{food}</h2> : null}
+          {availability[food]?.length > 0 ? <h2>{food}</h2> : null}
           {availability[food]?.length ? (
             <ul>
               {availability[food].map(({ restaurant, date }) => (

--- a/frontend/src/modules/Home/index.tsx
+++ b/frontend/src/modules/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 function Home() {
@@ -12,7 +12,7 @@ function Home() {
 
   const abortControllerRef = useRef<AbortController | null>(null)
 
-  const fetchFood = async (name: string) => {
+  const fetchFood = useCallback(async (name: string) => {
     if (name.length === 0) {
       setResponseData(null)
       setError(null)
@@ -46,7 +46,7 @@ function Home() {
     } finally {
       setLoading(false)
     }
-  }
+  }, [backendUrl]);
 
   useEffect(() => {
     const timer = setTimeout(() => {

--- a/frontend/src/modules/Home/index.tsx
+++ b/frontend/src/modules/Home/index.tsx
@@ -1,0 +1,92 @@
+import { useState, useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+function Home() {
+  const navigate = useNavigate()
+  const [foodName, setFoodName] = useState('')
+  const [responseData, setResponseData] = useState<any>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000'
+
+  const fetchFood = async (name: string) => {
+    if (name.length === 0) {
+      setResponseData(null)
+      setError(null)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    setResponseData(null)
+
+    try {
+      const response = await fetch(`${backendUrl}/?food=${encodeURIComponent(name)}`)
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`)
+      }
+      const data = await response.json()
+      setResponseData(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'An error occurred')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fetchFood(foodName)
+    }, 400)
+
+    return () => clearTimeout(timer)
+  }, [foodName])
+
+  return (
+    <>
+      <header style={{ display: 'flex', gap: '10px', marginBottom: '20px' }}>
+        <button onClick={() => navigate('/')}>Home</button>
+        <button onClick={() => navigate('/classics')}>Classics</button>
+      </header>
+      <h1>Unicafe foodfinder</h1>
+      <div className="input-container">
+        <input
+          type="text"
+          value={foodName}
+          onChange={(e) => setFoodName(e.target.value)}
+          placeholder="Enter food name"
+        />
+      </div>
+
+      {loading && <div style={{ marginTop: '20px' }}>Loading...</div>}
+
+      {error && <div style={{ color: 'red', marginTop: '20px' }}>Error: {error}</div>}
+
+      {responseData && (
+        <div>
+          <h2>Results:</h2>
+          <div>
+            {Object.entries(responseData).length === 0 && <p>No results found</p>}
+            {Object.entries(responseData).map(([restaurant, items]: [string, any]) => (
+              <div key={restaurant}>
+                <h3>{restaurant}</h3>
+                <div>
+                  {items.map((item: any[], index: number) => (
+                    <div key={index}>
+                      <div>- {item[0]}</div>
+                      <div>- {item[1]}</div>
+                      {item[2] && <>- Allergeenit: {item[2]}</>}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default Home

--- a/frontend/src/modules/Home/index.tsx
+++ b/frontend/src/modules/Home/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 function Home() {
@@ -10,6 +10,8 @@ function Home() {
 
   const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:3000'
 
+  const abortControllerRef = useRef<AbortController | null>(null)
+
   const fetchFood = async (name: string) => {
     if (name.length === 0) {
       setResponseData(null)
@@ -17,18 +19,29 @@ function Home() {
       return
     }
 
+    // Abort any ongoing request
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
     setLoading(true)
     setError(null)
     setResponseData(null)
 
     try {
-      const response = await fetch(`${backendUrl}/?food=${encodeURIComponent(name)}`)
+      const response = await fetch(`${backendUrl}/?food=${encodeURIComponent(name)}`, {
+        signal: controller.signal,
+      })
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`)
       }
       const data = await response.json()
       setResponseData(data)
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        // Request was aborted, do nothing
+        return
+      }
       setError(err instanceof Error ? err.message : 'An error occurred')
     } finally {
       setLoading(false)
@@ -40,7 +53,11 @@ function Home() {
       fetchFood(foodName)
     }, 400)
 
-    return () => clearTimeout(timer)
+    return () => {
+      clearTimeout(timer)
+      abortControllerRef.current?.abort()
+      abortControllerRef.current = null
+    }
   }, [foodName])
 
   return (


### PR DESCRIPTION
Implemented adding certified classics page that shows classic foods availability.

Deps added:
router

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces client-side routing and new data-fetching flows, plus changes backend log file path resolution for ESM which could affect logging in different runtimes/deploy paths.
> 
> **Overview**
> Adds React Router-based navigation and splits the previous single-page UI into a `Home` route (`/`) and a new **Certified classics** route (`/classics`) that fetches and displays availability for a fixed list of classic foods.
> 
> Updates frontend dependencies to include `react-router`/`react-router-dom` and adds the new `Classics` module; the backend logger middleware is adjusted to compute `__dirname` via `import.meta.url` so `backend.log` is written relative to the module in ESM environments. Also updates `.gitignore` to ignore `build/` and `*.log` files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09a1cab82fb8652445a7d1183f30de21411ec1ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->